### PR TITLE
Notifications Cleanup Background Job

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'omniauth-google-oauth2'
 gem 'omniauth-rails_csrf_protection', '~> 1.0'
 gem 'rolify'
 gem 'rubocop', '>= 1.0', '< 2.0'
+gem 'sidekiq'
 gem 'trix'
 gem 'will_paginate'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -254,6 +254,8 @@ GEM
     rake (13.1.0)
     rdoc (6.6.2)
       psych (>= 4.0.0)
+    redis-client (0.19.1)
+      connection_pool
     regexp_parser (2.8.3)
     reline (0.4.1)
       io-console (~> 0.5)
@@ -284,6 +286,11 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    sidekiq (7.2.1)
+      concurrent-ruby (< 2)
+      connection_pool (>= 2.3.0)
+      rack (>= 2.2.4)
+      redis-client (>= 0.19.0)
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
@@ -352,6 +359,7 @@ DEPENDENCIES
   rolify
   rubocop (>= 1.0, < 2.0)
   selenium-webdriver
+  sidekiq
   sprockets-rails
   stimulus-rails
   trix

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -4,6 +4,8 @@ class NotificationsController < ApplicationController
   def index
     return unless current_user
 
+    CleanupNotificationsJob.perform_async
+
     @notifications = current_user.notifications.order(created_at: :desc)
     respond_to do |format|
       format.html

--- a/app/sidekiq/cleanup_notifications_job.rb
+++ b/app/sidekiq/cleanup_notifications_job.rb
@@ -1,0 +1,7 @@
+class CleanupNotificationsJob
+  include Sidekiq::Job
+
+  def perform(*_args)
+    Notification.where('created_at < ?', 1.week.ago).destroy_all
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,11 +1,11 @@
 require_relative "boot"
-
+require 'dotenv'
 require "rails/all"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
-Dotenv::Railtie.load
+# Dotenv::Railtie.load
 
 module LyricalLabyrinth
   class Application < Rails::Application
@@ -16,6 +16,9 @@ module LyricalLabyrinth
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w(assets tasks))
+
+    # config/application.rb for sidekiq
+    config.active_job.queue_adapter = :sidekiq
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,35 @@
+:queues:
+  - default
+
+development:
+  :concurrency: 1
+  :logfile: ./log/sidekiq.log
+  :url: redis://localhost:6379/0
+
+:schedule:
+  cleanup_notifications:
+    every: '5m'
+    class: 'CleanupNotificationsWorker'
+
+# development:
+#   :concurrency: 5
+#   :logfile: ./log/sidekiq.log
+#   :url: redis://localhost:6379/0
+#   :queues:
+#     - default
+#     - high_priority
+#   :priority:
+#     - 0: 2    # Concurrency for default priority (default queue)
+#     - 10: 3   # Concurrency for higher priority (high_priority queue)
+
+
+# production:
+#   :concurrency: 5
+#   :logfile: ./log/sidekiq.log
+#   :url: redis://localhost:6379/0
+#   :queues:
+#     - default: 2
+#     - high_priority: 3
+
+
+# MyWorker.perform_async('arg1', 'arg2', priority: 10)

--- a/test/sidekiq/cleanup_notifications_job_test.rb
+++ b/test/sidekiq/cleanup_notifications_job_test.rb
@@ -1,0 +1,6 @@
+require 'test_helper'
+class CleanupNotificationsJobTest < Minitest::Test
+  def test_example
+    skip "add some examples to (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
## In this branch:

- I installed and configured `sidekiq` for processing background jobs in rails
- I created a `sidekiq` job, CleanupNotifications
- I scheduled the job to run periodically and clear stale notifications

### Up Next: Styling with Tailwind 🧷 
